### PR TITLE
feat: add manual stock API and display quantities

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -86,11 +86,6 @@ async function submitOrder(order) {
 async function checkout() {
   try {
     await submitOrder({ items: cart });
-    await fetch('/api/stock', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ items: cart })
-    });
     cart.length = 0;
     updateCart();
   } catch (err) {

--- a/data/stock.json
+++ b/data/stock.json
@@ -1,0 +1,4 @@
+[
+  { "Producto": "Al Haramain Amber Oud Gold Unisex 120ML", "Cantidad": 3 },
+  { "Producto": "Armaf Club de Nuit intense man EDT 100ML", "Cantidad": 0 }
+]

--- a/index.html
+++ b/index.html
@@ -754,6 +754,12 @@
         function createProductCard(p) {
             const card = document.createElement("div");
             card.className = "perfume-card bg-white rounded-lg overflow-hidden cursor-pointer";
+            const stockText = typeof p.stockQty === 'number'
+                ? (p.stockQty > 0 ? `Stock: ${p.stockQty}` : 'Sin stock')
+                : (p.stock ? 'Disponible' : 'Sin stock');
+            const stockColor = (typeof p.stockQty === 'number'
+                ? (p.stockQty > 0)
+                : p.stock) ? 'text-green-600' : 'text-red-600';
             card.innerHTML = `
                 <div class="w-full h-48 flex items-center justify-center bg-white">
                     <img src="${p.imagenes[0]}" alt="${p.nombre}" loading="lazy" class="max-h-full max-w-full object-contain">
@@ -761,6 +767,7 @@
                 <div class="p-4">
                     <h5 class="font-bold text-lg">${p.nombre}</h5>
                     <p class="text-gray-600 text-sm">$${p.precio.toLocaleString('es-AR')}</p>
+                    <p class="text-sm ${stockColor}">${stockText}</p>
                     <button class="compare-button mt-2 text-sm text-purple-600 hover:underline">Comparar</button>
                 </div>
             `;
@@ -856,12 +863,19 @@
             showImage(prod.imagenes[0], prod.nombre);
 
             const stockElement = document.getElementById('modal-stock');
-            if (prod.stock) {
-                stockElement.style.display = 'flex';
+            stockElement.style.display = 'flex';
+            if (typeof prod.stockQty === 'number') {
+                if (prod.stockQty > 0) {
+                    stockElement.textContent = `Stock: ${prod.stockQty}`;
+                    stockElement.className = 'flex items-center bg-green-100 text-green-800 text-xs px-2 py-1 rounded';
+                } else {
+                    stockElement.textContent = 'Sin stock';
+                    stockElement.className = 'flex items-center bg-red-100 text-red-800 text-xs px-2 py-1 rounded';
+                }
+            } else if (prod.stock) {
                 stockElement.textContent = 'Disponible';
                 stockElement.className = 'flex items-center bg-green-100 text-green-800 text-xs px-2 py-1 rounded';
             } else {
-                stockElement.style.display = 'flex';
                 stockElement.textContent = 'Sin stock';
                 stockElement.className = 'flex items-center bg-red-100 text-red-800 text-xs px-2 py-1 rounded';
             }
@@ -1036,7 +1050,10 @@
                 const stockData = await getStockLevels();
                 stockData.forEach(item => {
                     const prod = productos.find(p => p.nombre === item.Producto);
-                    if (prod) prod.stock = item.Cantidad > 0;
+                    if (prod) {
+                        prod.stockQty = item.Cantidad;
+                        prod.stock = item.Cantidad > 0;
+                    }
                 });
             } catch (err) {
                 console.error('Error fetching stock', err);

--- a/server.js
+++ b/server.js
@@ -1,10 +1,27 @@
 const express = require('express');
 const path = require('path');
+const fs = require('fs');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+const stockFile = path.join(__dirname, 'data', 'stock.json');
 
+app.use(express.json());
 app.use(express.static(__dirname));
+
+app.get('/api/stock', (req, res) => {
+  fs.readFile(stockFile, 'utf8', (err, data) => {
+    if (err) return res.status(500).json({ error: 'No se pudo leer el stock' });
+    res.json(JSON.parse(data));
+  });
+});
+
+app.post('/api/stock', (req, res) => {
+  fs.writeFile(stockFile, JSON.stringify(req.body, null, 2), 'utf8', err => {
+    if (err) return res.status(500).json({ error: 'No se pudo guardar el stock' });
+    res.json({ status: 'ok' });
+  });
+});
 
 app.listen(PORT, () => {
   console.log(`Servidor ejecutándose en puerto ${PORT}`);


### PR DESCRIPTION
## Summary
- add GET/POST `/api/stock` routes backed by `data/stock.json`
- fetch stock levels on load and show remaining units or `Sin stock`
- stop auto-adjusting inventory during checkout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894c94acdb08330aeae0f1ee3fd6acc