### PR TITLE
Corrige disponibilidad basada en stock

### DIFF
--- a/index.html
+++ b/index.html
@@ -1050,13 +1050,19 @@
 
         // Inicialización
         document.addEventListener('DOMContentLoaded', async () => {
+            const allProducts = [...productos, ...decants];
+            // Inicializar el stock en "sin stock" por defecto
+            allProducts.forEach(p => p.stock = false);
+
             try {
                 const stockData = await getStockLevels();
-                const allProducts = [...productos, ...decants];
                 stockData.forEach(item => {
-                    const prod = allProducts.find(p => p.nombre === item.Producto);
+                    const prod = allProducts.find(p =>
+                        p.nombre.trim().toLowerCase() === item.Producto.trim().toLowerCase()
+                    );
                     if (prod) {
-                        prod.stock = item.Cantidad !== 0;
+                        // Aseguramos que la cantidad se interprete como número
+                        prod.stock = Number(item.Cantidad) > 0;
                     }
                 });
             } catch (err) {

--- a/tests/stock.test.js
+++ b/tests/stock.test.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+test('actualiza el estado de stock en base a la cantidad', () => {
+  const productos = [
+    { nombre: 'Perfume A', stock: true },
+    { nombre: 'Perfume B', stock: true }
+  ];
+  const stockData = [
+    { Producto: 'Perfume A', Cantidad: 0 },
+    { Producto: 'Perfume B', Cantidad: 2 }
+  ];
+
+  const allProducts = [...productos];
+  allProducts.forEach(p => p.stock = false);
+  stockData.forEach(item => {
+    const prod = allProducts.find(p =>
+      p.nombre.trim().toLowerCase() === item.Producto.trim().toLowerCase()
+    );
+    if (prod) {
+      prod.stock = Number(item.Cantidad) > 0;
+    }
+  });
+
+  assert.strictEqual(allProducts[0].stock, false);
+  assert.strictEqual(allProducts[1].stock, true);
+});


### PR DESCRIPTION
## Summary
- Ajusta la carga de stock para marcar los perfumes sin stock por defecto y normalizar la comparación de nombres.
- Añade prueba que verifica la actualización del stock según el archivo de datos.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894f25dad148330a7e2a9f2f2aa1c66