### PR TITLE
Use stock file for inventory quantities

### DIFF
--- a/index.html
+++ b/index.html
@@ -400,7 +400,7 @@
                 similar: "Xerjoff Erba Pura",
                 comparaciones: [{ tienda: "FraganciasVIP", precio: 180000 }],
                 descripcion: "",
-                stock: true,
+                stock: 0,
                 notas: {
                     top: ["Bergamota", "Notas verdes"],
                     middle: ["Melón", "Piña", "Ámbar"],
@@ -415,7 +415,7 @@
                 similar: "Creed Aventus",
                 comparaciones: [{ tienda: "Creed Boutique", precio: 450000 }],
                 descripcion: "",
-                stock: true,
+                stock: 0,
                 notas: {
                     top: ["Limón", "Piña", "Bergamota", "Grosella negra", "Manzana"],
                     middle: ["Rosa", "Jazmín", "Abedul"],
@@ -430,7 +430,7 @@
                 similar: "Louis Vuitton Afternoon Swim",
                 comparaciones: [{ tienda: "Louis Vuitton", precio: 350000 }],
                 descripcion: "",
-                stock: true,
+                stock: 0,
                 notas: {
                     top: ["Mandarina", "Pomelo"],
                     middle: ["Cardamomo", "Especias", "Ámbar"],
@@ -445,7 +445,7 @@
                 similar: "Dior Sauvage Elixir",
                 comparaciones: [{ tienda: "Dior", precio: 260000 }],
                 descripcion: "",
-                stock: true,
+                stock: 0,
                 notas: {
                     top: ["Pimienta negra", "Piña", "Tabaco"],
                     middle: ["Café", "Vainilla", "Pachulí"],
@@ -458,7 +458,7 @@
                 categoria: "Árabes",
                 precio: 35000,
                 descripcion: "",
-                stock: true,
+                stock: 0,
                 notas: {
                     top: ["Mandarina", "Naranja"],
                     middle: ["Frutas tropicales", "Jazmín"],
@@ -471,7 +471,7 @@
                 categoria: "Árabes",
                 precio: 35000,
                 descripcion: "",
-                stock: true,
+                stock: 0,
                 notas: {
                     top: ["Malvavisco", "Bergamota", "Flores blancas"],
                     middle: ["Caramelo", "Durazno", "Azúcar"],
@@ -486,7 +486,7 @@
                 similar: "Kilian Angels' Share",
                 comparaciones: [{ tienda: "Kilian Official", precio: 320000 }],
                 descripcion: "",
-                stock: true,
+                stock: 0,
                 notas: {
                     top: ["Canela", "Nuez moscada", "Bergamota"],
                     middle: ["Dátiles", "Praliné", "Nardos"],
@@ -499,7 +499,7 @@
                 categoria: "Árabes",
                 precio: 40000,
                 descripcion: "",
-                stock: true,
+                stock: 0,
                 notas: {
                     top: ["Azafrán", "Bergamota"],
                     middle: ["Rosa", "Madera de ámbar"],
@@ -512,7 +512,7 @@
                 categoria: "Árabes",
                 precio: 48000,
                 descripcion: "",
-                stock: true,
+                stock: 0,
                 notas: {
                     top: ["Azafrán", "Lavanda", "Nuez moscada"],
                     middle: ["Oud", "Pachulí", "Rosa"],
@@ -525,7 +525,7 @@
                 categoria: "Árabes",
                 precio: 48000,
                 descripcion: "",
-                stock: true,
+                stock: 0,
                 notas: {
                     top: ["Rosa", "Bergamota"],
                     middle: ["Rosa turca", "Rosa búlgara", "Jazmín"],
@@ -538,7 +538,7 @@
                 categoria: "Árabes",
                 precio: 34000,
                 descripcion: "",
-                stock: true,
+                stock: 0,
                 notas: {
                     top: ["Mandarina", "Cardamomo"],
                     middle: ["Lavanda", "Geranio"],
@@ -552,7 +552,7 @@
                 precio: 35000,
                 comparaciones: [{ tienda: "Mercado Libre", precio: 55000 }],
                 descripcion: "",
-                stock: true,
+                stock: 0,
                 notas: {
                     top: ["Pimienta negra", "Piña", "Tabaco"],
                     middle: ["Café", "Vainilla", "Pachulí"],
@@ -565,7 +565,7 @@
                 categoria: "Árabes",
                 precio: 45000,
                 descripcion: "",
-                stock: true,
+                stock: 0,
                 notas: {
                     top: ["Ananá", "Pomelo"],
                     middle: ["Lavanda", "Pachulí"],
@@ -579,7 +579,7 @@
                 categoria: "Diseñador",
                 precio: 11111,
                 descripcion: "",
-                stock: false,
+                stock: 0,
                 notas: {
                     top: ["Cardamomo"],
                     middle: ["Toffee"],
@@ -592,7 +592,7 @@
                 categoria: "Diseñador",
                 precio: 11111,
                 descripcion: "",
-                stock: false,
+                stock: 0,
                 notas: {
                     top: ["Grosella roja", "Mandarina", "Lichi"],
                     middle: ["Rosa", "Flor de durazno", "Peonía"],
@@ -605,7 +605,7 @@
                 categoria: "Diseñador",
                 precio: 1111111,
                 descripcion: "",
-                stock: false,
+                stock: 0,
                 notas: {
                     top: ["Almendra", "Café", "Bergamota"],
                     middle: ["Jazmín sambac", "Nardos", "Raíz de lirio"],
@@ -618,7 +618,7 @@
                 categoria: "Diseñador",
                 precio: 1111111,
                 descripcion: "",
-                stock: false,
+                stock: 0,
                 notas: {
                     top: ["Bergamota", "Pimienta"],
                     middle: ["Lavanda", "Pimienta de Sichuan", "Anís estrellado", "Nuez moscada"],
@@ -631,7 +631,7 @@
                 categoria: "Diseñador",
                 precio: 11111,
                 descripcion: "",
-                stock: false,
+                stock: 0,
                 notas: {
                     top: ["Menta", "Lavanda"],
                     middle: ["Vainilla", "Benjuí"],
@@ -644,7 +644,7 @@
                 categoria: "Diseñador",
                 precio: 11111111,
                 descripcion: "",
-                stock: false,
+                stock: 0,
                 notas: {
                     top: ["Grosella negra", "Pimienta rosa", "Bergamota"],
                     middle: ["Jazmín", "Té de jazmín"],
@@ -657,7 +657,7 @@
                 categoria: "Diseñador",
                 precio: 111111,
                 descripcion: "",
-                stock: false,
+                stock: 0,
                 notas: {
                     top: ["Bergamota", "Pomelo", "Hoja de higuera"],
                     middle: ["Hoja de violeta", "Papiro", "Pachulí", "Pimienta negra"],
@@ -674,7 +674,7 @@
                 categoria: "Decant Árabe",
                 precio: 111111,
                 descripcion: "",
-                stock: false,
+                stock: 0,
                 notas: {
                     top: ["Bergamota", "Notas verdes"],
                     middle: ["Melón", "Piña", "Ámbar"],
@@ -687,7 +687,7 @@
                 categoria: "Decant Diseñador",
                 precio: 1111111,
                 descripcion: "",
-                stock: false,
+                stock: 0,
                 notas: {
                     top: ["Bergamota", "Pimienta"],
                     middle: ["Lavanda", "Pimienta de Sichuan", "Anís estrellado", "Nuez moscada"],
@@ -700,7 +700,7 @@
                 categoria: "Decant Diseñador",
                 precio: 1111111,
                 descripcion: "",
-                stock: false,
+                stock: 0,
                 notas: {
                     top: ["Menta", "Lavanda"],
                     middle: ["Vainilla", "Benjuí"],
@@ -713,7 +713,7 @@
                 categoria: "Decant Árabe",
                 precio: 111111,
                 descripcion: "",
-                stock: false,
+                stock: 0,
                 notas: {
                     top: ["Canela", "Nuez moscada", "Bergamota"],
                     middle: ["Dátiles", "Praliné", "Nardos"],
@@ -754,8 +754,9 @@
         function createProductCard(p) {
             const card = document.createElement("div");
             card.className = "perfume-card bg-white rounded-lg overflow-hidden cursor-pointer";
-            const stockText = p.stock ? 'Disponible' : 'Sin stock';
-            const stockColor = p.stock ? 'text-green-600' : 'text-red-600';
+            const stockNumber = Number(p.stock) || 0;
+            const stockText = stockNumber > 0 ? `Stock: ${stockNumber}` : 'Sin stock';
+            const stockColor = stockNumber > 0 ? 'text-green-600' : 'text-red-600';
             card.innerHTML = `
                 <div class="w-full h-48 flex items-center justify-center bg-white">
                     <img src="${p.imagenes[0]}" alt="${p.nombre}" loading="lazy" class="max-h-full max-w-full object-contain">
@@ -876,8 +877,9 @@
 
             const stockElement = document.getElementById('modal-stock');
             stockElement.style.display = 'flex';
-            if (prod.stock) {
-                stockElement.textContent = 'Disponible';
+            const stockNumber = Number(prod.stock) || 0;
+            if (stockNumber > 0) {
+                stockElement.textContent = `Stock: ${stockNumber}`;
                 stockElement.className = 'flex items-center bg-green-100 text-green-800 text-xs px-2 py-1 rounded';
             } else {
                 stockElement.textContent = 'Sin stock';
@@ -1051,8 +1053,8 @@
         // Inicialización
         document.addEventListener('DOMContentLoaded', async () => {
             const allProducts = [...productos, ...decants];
-            // Inicializar el stock en "sin stock" por defecto
-            allProducts.forEach(p => p.stock = false);
+            // Inicializar el stock con 0 por defecto
+            allProducts.forEach(p => p.stock = 0);
 
             try {
                 const stockData = await getStockLevels();
@@ -1062,7 +1064,7 @@
                     );
                     if (prod) {
                         // Aseguramos que la cantidad se interprete como número
-                        prod.stock = Number(item.Cantidad) > 0;
+                        prod.stock = Number(item.Cantidad) || 0;
                     }
                 });
             } catch (err) {

--- a/tests/stock.test.js
+++ b/tests/stock.test.js
@@ -1,10 +1,10 @@
 const test = require('node:test');
 const assert = require('node:assert');
 
-test('actualiza el estado de stock en base a la cantidad', () => {
+test('actualiza las cantidades de stock', () => {
   const productos = [
-    { nombre: 'Perfume A', stock: true },
-    { nombre: 'Perfume B', stock: true }
+    { nombre: 'Perfume A', stock: 0 },
+    { nombre: 'Perfume B', stock: 0 }
   ];
   const stockData = [
     { Producto: 'Perfume A', Cantidad: 0 },
@@ -12,16 +12,16 @@ test('actualiza el estado de stock en base a la cantidad', () => {
   ];
 
   const allProducts = [...productos];
-  allProducts.forEach(p => p.stock = false);
+  allProducts.forEach(p => p.stock = 0);
   stockData.forEach(item => {
     const prod = allProducts.find(p =>
       p.nombre.trim().toLowerCase() === item.Producto.trim().toLowerCase()
     );
     if (prod) {
-      prod.stock = Number(item.Cantidad) > 0;
+      prod.stock = Number(item.Cantidad) || 0;
     }
   });
 
-  assert.strictEqual(allProducts[0].stock, false);
-  assert.strictEqual(allProducts[1].stock, true);
+  assert.strictEqual(allProducts[0].stock, 0);
+  assert.strictEqual(allProducts[1].stock, 2);
 });


### PR DESCRIPTION
## Summary
- Derive product availability from `data/stock.json` and show remaining units on cards and in modal
- Initialize and update numeric stock counts on load
- Adjust tests for numeric stock quantities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894f8db6bc083308d451e9c0eaa49c0