### PR TITLE
Use stock file for inventory quantities

### DIFF
--- a/index.html
+++ b/index.html
@@ -400,7 +400,6 @@
                 similar: "Xerjoff Erba Pura",
                 comparaciones: [{ tienda: "FraganciasVIP", precio: 180000 }],
                 descripcion: "",
-                stock: true,
                 notas: {
                     top: ["Bergamota", "Notas verdes"],
                     middle: ["Melón", "Piña", "Ámbar"],
@@ -415,7 +414,6 @@
                 similar: "Creed Aventus",
                 comparaciones: [{ tienda: "Creed Boutique", precio: 450000 }],
                 descripcion: "",
-                stock: true,
                 notas: {
                     top: ["Limón", "Piña", "Bergamota", "Grosella negra", "Manzana"],
                     middle: ["Rosa", "Jazmín", "Abedul"],
@@ -430,7 +428,6 @@
                 similar: "Louis Vuitton Afternoon Swim",
                 comparaciones: [{ tienda: "Louis Vuitton", precio: 350000 }],
                 descripcion: "",
-                stock: true,
                 notas: {
                     top: ["Mandarina", "Pomelo"],
                     middle: ["Cardamomo", "Especias", "Ámbar"],
@@ -445,7 +442,6 @@
                 similar: "Dior Sauvage Elixir",
                 comparaciones: [{ tienda: "Dior", precio: 260000 }],
                 descripcion: "",
-                stock: true,
                 notas: {
                     top: ["Pimienta negra", "Piña", "Tabaco"],
                     middle: ["Café", "Vainilla", "Pachulí"],
@@ -458,7 +454,6 @@
                 categoria: "Árabes",
                 precio: 35000,
                 descripcion: "",
-                stock: true,
                 notas: {
                     top: ["Mandarina", "Naranja"],
                     middle: ["Frutas tropicales", "Jazmín"],
@@ -471,7 +466,6 @@
                 categoria: "Árabes",
                 precio: 35000,
                 descripcion: "",
-                stock: true,
                 notas: {
                     top: ["Malvavisco", "Bergamota", "Flores blancas"],
                     middle: ["Caramelo", "Durazno", "Azúcar"],
@@ -486,7 +480,6 @@
                 similar: "Kilian Angels' Share",
                 comparaciones: [{ tienda: "Kilian Official", precio: 320000 }],
                 descripcion: "",
-                stock: true,
                 notas: {
                     top: ["Canela", "Nuez moscada", "Bergamota"],
                     middle: ["Dátiles", "Praliné", "Nardos"],
@@ -499,7 +492,6 @@
                 categoria: "Árabes",
                 precio: 40000,
                 descripcion: "",
-                stock: true,
                 notas: {
                     top: ["Azafrán", "Bergamota"],
                     middle: ["Rosa", "Madera de ámbar"],
@@ -512,7 +504,6 @@
                 categoria: "Árabes",
                 precio: 48000,
                 descripcion: "",
-                stock: true,
                 notas: {
                     top: ["Azafrán", "Lavanda", "Nuez moscada"],
                     middle: ["Oud", "Pachulí", "Rosa"],
@@ -525,7 +516,6 @@
                 categoria: "Árabes",
                 precio: 48000,
                 descripcion: "",
-                stock: true,
                 notas: {
                     top: ["Rosa", "Bergamota"],
                     middle: ["Rosa turca", "Rosa búlgara", "Jazmín"],
@@ -538,7 +528,6 @@
                 categoria: "Árabes",
                 precio: 34000,
                 descripcion: "",
-                stock: true,
                 notas: {
                     top: ["Mandarina", "Cardamomo"],
                     middle: ["Lavanda", "Geranio"],
@@ -552,7 +541,6 @@
                 precio: 35000,
                 comparaciones: [{ tienda: "Mercado Libre", precio: 55000 }],
                 descripcion: "",
-                stock: true,
                 notas: {
                     top: ["Pimienta negra", "Piña", "Tabaco"],
                     middle: ["Café", "Vainilla", "Pachulí"],
@@ -565,7 +553,6 @@
                 categoria: "Árabes",
                 precio: 45000,
                 descripcion: "",
-                stock: true,
                 notas: {
                     top: ["Ananá", "Pomelo"],
                     middle: ["Lavanda", "Pachulí"],
@@ -579,7 +566,6 @@
                 categoria: "Diseñador",
                 precio: 11111,
                 descripcion: "",
-                stock: false,
                 notas: {
                     top: ["Cardamomo"],
                     middle: ["Toffee"],
@@ -592,7 +578,6 @@
                 categoria: "Diseñador",
                 precio: 11111,
                 descripcion: "",
-                stock: false,
                 notas: {
                     top: ["Grosella roja", "Mandarina", "Lichi"],
                     middle: ["Rosa", "Flor de durazno", "Peonía"],
@@ -605,7 +590,6 @@
                 categoria: "Diseñador",
                 precio: 1111111,
                 descripcion: "",
-                stock: false,
                 notas: {
                     top: ["Almendra", "Café", "Bergamota"],
                     middle: ["Jazmín sambac", "Nardos", "Raíz de lirio"],
@@ -618,7 +602,6 @@
                 categoria: "Diseñador",
                 precio: 1111111,
                 descripcion: "",
-                stock: false,
                 notas: {
                     top: ["Bergamota", "Pimienta"],
                     middle: ["Lavanda", "Pimienta de Sichuan", "Anís estrellado", "Nuez moscada"],
@@ -631,7 +614,6 @@
                 categoria: "Diseñador",
                 precio: 11111,
                 descripcion: "",
-                stock: false,
                 notas: {
                     top: ["Menta", "Lavanda"],
                     middle: ["Vainilla", "Benjuí"],
@@ -644,7 +626,6 @@
                 categoria: "Diseñador",
                 precio: 11111111,
                 descripcion: "",
-                stock: false,
                 notas: {
                     top: ["Grosella negra", "Pimienta rosa", "Bergamota"],
                     middle: ["Jazmín", "Té de jazmín"],
@@ -657,7 +638,6 @@
                 categoria: "Diseñador",
                 precio: 111111,
                 descripcion: "",
-                stock: false,
                 notas: {
                     top: ["Bergamota", "Pomelo", "Hoja de higuera"],
                     middle: ["Hoja de violeta", "Papiro", "Pachulí", "Pimienta negra"],
@@ -674,7 +654,6 @@
                 categoria: "Decant Árabe",
                 precio: 111111,
                 descripcion: "",
-                stock: false,
                 notas: {
                     top: ["Bergamota", "Notas verdes"],
                     middle: ["Melón", "Piña", "Ámbar"],
@@ -687,7 +666,6 @@
                 categoria: "Decant Diseñador",
                 precio: 1111111,
                 descripcion: "",
-                stock: false,
                 notas: {
                     top: ["Bergamota", "Pimienta"],
                     middle: ["Lavanda", "Pimienta de Sichuan", "Anís estrellado", "Nuez moscada"],
@@ -700,7 +678,6 @@
                 categoria: "Decant Diseñador",
                 precio: 1111111,
                 descripcion: "",
-                stock: false,
                 notas: {
                     top: ["Menta", "Lavanda"],
                     middle: ["Vainilla", "Benjuí"],
@@ -713,7 +690,6 @@
                 categoria: "Decant Árabe",
                 precio: 111111,
                 descripcion: "",
-                stock: false,
                 notas: {
                     top: ["Canela", "Nuez moscada", "Bergamota"],
                     middle: ["Dátiles", "Praliné", "Nardos"],
@@ -751,11 +727,21 @@
             });
         }
 
+        function formatStockInfo(stock) {
+            const num = Number(stock) || 0;
+            return {
+                text: num > 0 ? `Stock: ${num}` : 'Sin stock',
+                textColor: num > 0 ? 'text-green-600' : 'text-red-600',
+                badgeClass: num > 0
+                    ? 'flex items-center bg-green-100 text-green-800 text-xs px-2 py-1 rounded'
+                    : 'flex items-center bg-red-100 text-red-800 text-xs px-2 py-1 rounded'
+            };
+        }
+
         function createProductCard(p) {
             const card = document.createElement("div");
             card.className = "perfume-card bg-white rounded-lg overflow-hidden cursor-pointer";
-            const stockText = p.stock ? 'Disponible' : 'Sin stock';
-            const stockColor = p.stock ? 'text-green-600' : 'text-red-600';
+            const { text: stockText, textColor: stockColor } = formatStockInfo(p.stock);
             card.innerHTML = `
                 <div class="w-full h-48 flex items-center justify-center bg-white">
                     <img src="${p.imagenes[0]}" alt="${p.nombre}" loading="lazy" class="max-h-full max-w-full object-contain">
@@ -875,14 +861,10 @@
             showImage(prod.imagenes[0], prod.nombre);
 
             const stockElement = document.getElementById('modal-stock');
+            const { text, badgeClass } = formatStockInfo(prod.stock);
             stockElement.style.display = 'flex';
-            if (prod.stock) {
-                stockElement.textContent = 'Disponible';
-                stockElement.className = 'flex items-center bg-green-100 text-green-800 text-xs px-2 py-1 rounded';
-            } else {
-                stockElement.textContent = 'Sin stock';
-                stockElement.className = 'flex items-center bg-red-100 text-red-800 text-xs px-2 py-1 rounded';
-            }
+            stockElement.textContent = text;
+            stockElement.className = badgeClass;
 
             // Miniaturas
             const thumbs = document.getElementById('thumbnails');
@@ -1051,8 +1033,6 @@
         // Inicialización
         document.addEventListener('DOMContentLoaded', async () => {
             const allProducts = [...productos, ...decants];
-            // Inicializar el stock en "sin stock" por defecto
-            allProducts.forEach(p => p.stock = false);
 
             try {
                 const stockData = await getStockLevels();
@@ -1062,7 +1042,7 @@
                     );
                     if (prod) {
                         // Aseguramos que la cantidad se interprete como número
-                        prod.stock = Number(item.Cantidad) > 0;
+                        prod.stock = Number(item.Cantidad) || 0;
                     }
                 });
             } catch (err) {

--- a/tests/stock.test.js
+++ b/tests/stock.test.js
@@ -1,10 +1,10 @@
 const test = require('node:test');
 const assert = require('node:assert');
 
-test('actualiza el estado de stock en base a la cantidad', () => {
+test('actualiza las cantidades de stock', () => {
   const productos = [
-    { nombre: 'Perfume A', stock: true },
-    { nombre: 'Perfume B', stock: true }
+    { nombre: 'Perfume A' },
+    { nombre: 'Perfume B' }
   ];
   const stockData = [
     { Producto: 'Perfume A', Cantidad: 0 },
@@ -12,16 +12,15 @@ test('actualiza el estado de stock en base a la cantidad', () => {
   ];
 
   const allProducts = [...productos];
-  allProducts.forEach(p => p.stock = false);
   stockData.forEach(item => {
     const prod = allProducts.find(p =>
       p.nombre.trim().toLowerCase() === item.Producto.trim().toLowerCase()
     );
     if (prod) {
-      prod.stock = Number(item.Cantidad) > 0;
+      prod.stock = Number(item.Cantidad) || 0;
     }
   });
 
-  assert.strictEqual(allProducts[0].stock, false);
-  assert.strictEqual(allProducts[1].stock, true);
+  assert.strictEqual(allProducts[0].stock, 0);
+  assert.strictEqual(allProducts[1].stock, 2);
 });


### PR DESCRIPTION
## Summary
- Remove hardcoded stock fields from product definitions and rely on `data/stock.json`
- Consolidate stock display logic in a reusable `formatStockInfo` helper for cards and modal
- Adjust stock test fixtures to omit default stock values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894f8db6bc083308d451e9c0eaa49c0