### PR TITLE
Fix stock info for product cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -761,6 +761,7 @@
         }
 
         function createProductCard(p) {
+            const { text: stockText, textColor: stockColor } = formatStockInfo(p.stock);
             const card = document.createElement("div");
             card.className = "perfume-card bg-white rounded-lg overflow-hidden cursor-pointer";
 

--- a/tests/stock.test.js
+++ b/tests/stock.test.js
@@ -3,7 +3,8 @@ const assert = require('node:assert');
 
 test('actualiza las cantidades de stock', () => {
   const productos = [
-
+    { nombre: 'Perfume A', stock: 5 },
+    { nombre: 'Perfume B', stock: 1 }
   ];
   const stockData = [
     { Producto: 'Perfume A', Cantidad: 0 },


### PR DESCRIPTION
## Summary
- compute stock info when rendering product cards so perfumes appear again
- add sample products in stock test to cover stock updating

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68950505c43c83309d0611d1d0638387