### PR TITLE
Load stock directly from JSON file

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -68,7 +68,7 @@ function updateCart() {
 }
 
 async function getStockLevels() {
-  const res = await fetch('/api/stock');
+  const res = await fetch('data/stock.json');
   if (!res.ok) throw new Error('Failed to fetch stock');
   return res.json();
 }


### PR DESCRIPTION
## Summary
- Fetch stock levels from `data/stock.json` in the cart script to allow static hosting without a Node backend.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895071bf0308330bac87723951b05dc