### PR TITLE
Poll stock API for live inventory

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -68,7 +68,9 @@ function updateCart() {
 }
 
 async function getStockLevels() {
-  const res = await fetch('data/stock.json');
+  const res = await fetch(`/api/stock?t=${Date.now()}`, {
+    cache: 'no-store'
+  });
   if (!res.ok) throw new Error('Failed to fetch stock');
   return res.json();
 }

--- a/index.html
+++ b/index.html
@@ -1056,23 +1056,26 @@
         document.addEventListener('DOMContentLoaded', async () => {
             const allProducts = [...productos, ...decants];
 
-
-            try {
-                const stockData = await getStockLevels();
-                stockData.forEach(item => {
-                    const prod = allProducts.find(p =>
-                        p.nombre.trim().toLowerCase() === item.Producto.trim().toLowerCase()
-                    );
-                    if (prod) {
-                        // Aseguramos que la cantidad se interprete como número
-                        prod.stock = Number(item.Cantidad) || 0;
-                    }
-                });
-            } catch (err) {
-                console.error('Error fetching stock', err);
+            async function refreshStock() {
+                try {
+                    const stockData = await getStockLevels();
+                    stockData.forEach(item => {
+                        const prod = allProducts.find(p =>
+                            p.nombre.trim().toLowerCase() === item.Producto.trim().toLowerCase()
+                        );
+                        if (prod) {
+                            prod.stock = Number(item.Cantidad) || 0;
+                        }
+                    });
+                    renderProductos();
+                } catch (err) {
+                    console.error('Error fetching stock', err);
+                }
             }
-            renderProductos();
+
+            await refreshStock();
             updateCompareButton();
+            setInterval(refreshStock, 60000);
 
             const orderForm = document.getElementById('order-form');
             if (orderForm) {


### PR DESCRIPTION
## Summary
- Fetch stock levels from `/api/stock` with cache-busting to ensure fresh data
- Periodically refresh product stock on the client every minute to keep inventory in sync

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68968d7368a48330a1986fc71e75a952