### PR TITLE
Render products even when stock API fails

### DIFF
--- a/index.html
+++ b/index.html
@@ -1106,9 +1106,12 @@
                             prod.stock = Number(item.Cantidad) || 0;
                         }
                     });
-                    renderProductos();
                 } catch (err) {
                     console.error('Error fetching stock', err);
+                } finally {
+                    // Renderizamos los productos aunque falle la carga de stock
+                    // para que el catálogo sea visible con stock por defecto
+                    renderProductos();
                 }
             }
 


### PR DESCRIPTION
## Summary
- Always render product catalog even if stock endpoint fails, so perfumes remain visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896950fe4408330aec41916154b4351