### PR TITLE
Ensure stock data loads before rendering catalog

### DIFF
--- a/index.html
+++ b/index.html
@@ -1074,11 +1074,8 @@
         });
 
         // Inicialización
-        document.addEventListener('DOMContentLoaded', () => {
+        document.addEventListener('DOMContentLoaded', async () => {
             const allProducts = [...productos, ...decants];
-
-            // Renderizamos inicialmente para mostrar el catálogo sin depender del stock
-            renderProductos();
 
             async function refreshStock() {
                 try {
@@ -1099,8 +1096,8 @@
                 }
             }
 
-            // Actualizamos el stock en segundo plano
-            refreshStock();
+            // Cargamos el stock antes de renderizar el catálogo
+            await refreshStock();
             updateCompareButton();
             setInterval(refreshStock, 60000);
 


### PR DESCRIPTION
## Summary
- Load product stock from the server before first render so stock for Arab perfumes appears immediately

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68969a1863108330803805cad9be12a5