### PR TITLE
Fix stock display fallback

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -95,9 +95,15 @@ function updateCart() {
 
 async function getStockLevels() {
   if (stockClient) return stockClient.getAll();
-  const res = await fetch(`/api/stock?t=${Date.now()}`, { cache: 'no-store' });
-  if (!res.ok) throw new Error('Failed to fetch stock');
-  return res.json();
+  try {
+    const res = await fetch(`/api/stock?t=${Date.now()}`, { cache: 'no-store' });
+    if (!res.ok) throw new Error('API unavailable');
+    return res.json();
+  } catch (err) {
+    const res = await fetch(`/data/stock.json?t=${Date.now()}`, { cache: 'no-store' });
+    if (!res.ok) throw new Error('Failed to fetch stock');
+    return res.json();
+  }
 }
 
 async function submitOrder(order) {


### PR DESCRIPTION
## Summary
- Fallback to local stock data when API unavailable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa2e0a9b5083309005e8ca277ae4fc